### PR TITLE
Make `email` property no longer required

### DIFF
--- a/server/openapi_server/dbmodels/person.py
+++ b/server/openapi_server/dbmodels/person.py
@@ -8,7 +8,7 @@ class Person(Document):
     personId = ObjectIdField(primary_key=True, default=ObjectId)
     firstName = StringField(required=True)
     lastName = StringField(required=True)
-    email = EmailField(unique=True)
+    email = EmailField()  # TODO: maybe make unique again later?
     organizations = ListField(ReferenceField(Organization))
 
     def to_dict(self):

--- a/server/openapi_server/dbmodels/user.py
+++ b/server/openapi_server/dbmodels/user.py
@@ -9,7 +9,7 @@ class User(Document):
     role = StringField(choices=["user", "admin"], default="user")
     firstName = StringField(required=True)
     lastName = StringField(required=True)
-    email = EmailField(unique=True)
+    email = EmailField()  # TODO: maybe make unique again later?
     organizations = ListField(ReferenceField(Organization))
 
     def to_dict(self):

--- a/server/openapi_server/models/person.py
+++ b/server/openapi_server/models/person.py
@@ -155,8 +155,6 @@ class Person(Model):
         :param email: The email of this Person.
         :type email: str
         """
-        if email is None:
-            raise ValueError("Invalid value for `email`, must not be `None`")  # noqa: E501
 
         self._email = email
 

--- a/server/openapi_server/models/person_create_request.py
+++ b/server/openapi_server/models/person_create_request.py
@@ -127,8 +127,6 @@ class PersonCreateRequest(Model):
         :param email: The email of this PersonCreateRequest.
         :type email: str
         """
-        if email is None:
-            raise ValueError("Invalid value for `email`, must not be `None`")  # noqa: E501
 
         self._email = email
 

--- a/server/openapi_server/models/user.py
+++ b/server/openapi_server/models/user.py
@@ -196,8 +196,6 @@ class User(Model):
         :param email: The email of this User.
         :type email: str
         """
-        if email is None:
-            raise ValueError("Invalid value for `email`, must not be `None`")  # noqa: E501
 
         self._email = email
 

--- a/server/openapi_server/models/user_create_request.py
+++ b/server/openapi_server/models/user_create_request.py
@@ -127,8 +127,6 @@ class UserCreateRequest(Model):
         :param email: The email of this UserCreateRequest.
         :type email: str
         """
-        if email is None:
-            raise ValueError("Invalid value for `email`, must not be `None`")  # noqa: E501
 
         self._email = email
 

--- a/server/openapi_server/openapi/openapi.yaml
+++ b/server/openapi_server/openapi/openapi.yaml
@@ -1409,7 +1409,6 @@ components:
             $ref: '#/components/schemas/OrganizationId'
           type: array
       required:
-      - email
       - firstName
       - lastName
       type: object

--- a/server/openapi_server/test/integration/test_person_controller.py
+++ b/server/openapi_server/test/integration/test_person_controller.py
@@ -119,28 +119,29 @@ class TestPersonController(BaseTestCase):
             f"Response body is: {response.data.decode('utf-8')}"
         )
 
-    def test_create_person_with_status409(self):
-        """Test case for create_person
+    # TODO: comment back in once `email` must be unique again
+    # def test_create_person_with_status409(self):
+    #     """Test case for create_person
 
-        Create a duplicate person (409)
-        """
-        util.create_test_person(["awesome-organization"])
-        person = {
-            'firstName': "Awesome",
-            'lastName': "Person",
-            'organizations': ["awesome-organization"],
-            'email': "awesome-person@example.org"
-        }
-        response = self.client.open(
-            "/api/v1/persons",
-            method="POST",
-            headers=REQUEST_HEADERS,
-            data=json.dumps(person)
-        )
-        self.assertStatus(
-            response, 409,
-            f"Response body is: {response.data.decode('utf-8')}"
-        )
+    #     Create a duplicate person (409)
+    #     """
+    #     util.create_test_person(["awesome-organization"])
+    #     person = {
+    #         'firstName': "Awesome",
+    #         'lastName': "Person",
+    #         'organizations': ["awesome-organization"],
+    #         'email': "awesome-person@example.org"
+    #     }
+    #     response = self.client.open(
+    #         "/api/v1/persons",
+    #         method="POST",
+    #         headers=REQUEST_HEADERS,
+    #         data=json.dumps(person)
+    #     )
+    #     self.assertStatus(
+    #         response, 409,
+    #         f"Response body is: {response.data.decode('utf-8')}"
+    #     )
 
     def test_delete_person_with_status200(self):
         """Test case for delete_person

--- a/server/openapi_server/test/integration/test_person_model.py
+++ b/server/openapi_server/test/integration/test_person_model.py
@@ -32,14 +32,6 @@ class TestPersonModel(BaseTestCase):
         with self.assertRaises(ValueError):
             self.person.last_name = None
 
-    def test_missing_email(self):
-        """Test case for Person
-
-        Set the email to None
-        """
-        with self.assertRaises(ValueError):
-            self.person.email = None
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As noted [in this PR](https://github.com/Sage-Bionetworks/rocc-schemas/pull/66), `email` should not be a required property at this moment, as the current DREAM Landscape does not capture this information.