### PR TITLE
Fix totalResults and enble to delete all entities of a given schema type

### DIFF
--- a/server/openapi_server/controllers/challenge_controller.py
+++ b/server/openapi_server/controllers/challenge_controller.py
@@ -143,6 +143,7 @@ def list_challenges(limit=None, offset=None, filter_=None):
     res = None
     status = None
     try:
+        # Get results based on query, limit and offset.
         name_q = Q(name__istartswith=filter_['name']) \
             if 'name' in filter_ else Q()
         status_q = Q(status=filter_['status']) \
@@ -159,13 +160,17 @@ def list_challenges(limit=None, offset=None, filter_=None):
         if len(challenges) == limit:
             next_ = "%s/challenges?limit=%s&offset=%s" % \
                 (Config().server_api_url, limit, offset + limit)
+
+        # Get total results count.
+        total = DbChallenge.objects.count()
+
         res = PageOfChallenges(
             offset=offset,
             limit=limit,
             links={
                 "next": next_
             },
-            total_results=len(challenges),
+            total_results=total,
             challenges=challenges)
         status = 200
     except TypeError:  # TODO: may need different exception

--- a/server/openapi_server/controllers/challenge_controller.py
+++ b/server/openapi_server/controllers/challenge_controller.py
@@ -175,3 +175,26 @@ def list_challenges(limit=None, offset=None, filter_=None):
         status = 500
         res = Error("Internal error", status, str(error))
     return res, status
+
+
+def delete_all_challenges():
+    """Delete all challenges
+
+    Delete all challenges
+
+    :rtype: object
+    """
+    res = None
+    status = None
+    try:
+        DbChallenge.objects.delete()
+        res = {}
+        status = 200
+    # TODO: find an exception that will raise 400 error
+    # except DoesNotExist:
+    #     status = 400
+    #     res = Error("Bad request", status)
+    except Exception as error:
+        status = 500
+        res = Error("Internal error", status, str(error))
+    return res, status

--- a/server/openapi_server/controllers/grant_controller.py
+++ b/server/openapi_server/controllers/grant_controller.py
@@ -129,3 +129,26 @@ def list_grants(limit=None, offset=None):
         status = 500
         res = Error("Internal error", status, str(error))
     return res, status
+
+
+def delete_all_grants():
+    """Delete all grants
+
+    Delete all grants # noqa: E501
+
+    :rtype: object
+    """
+    res = None
+    status = None
+    try:
+        DbGrant.objects.delete()
+        res = {}
+        status = 200
+    # TODO: find an exception that will raise 400 error
+    # except DoesNotExist:
+    #     status = 400
+    #     res = Error("Bad request", status)
+    except Exception as error:
+        status = 500
+        res = Error("Internal error", status, str(error))
+    return res, status

--- a/server/openapi_server/controllers/grant_controller.py
+++ b/server/openapi_server/controllers/grant_controller.py
@@ -107,19 +107,24 @@ def list_grants(limit=None, offset=None):
     res = None
     status = None
     try:
+        # Get results based on limit and offset.
         db_grants = DbGrant.objects.skip(offset).limit(limit)
         grants = [Grant.from_dict(d.to_dict()) for d in db_grants]
         next_ = ""
         if len(grants) == limit:
             next_ = "%s/grants?limit=%s&offset=%s" % \
                 (Config().server_api_url, limit, offset + limit)
+
+        # Get total results count.
+        total = DbGrant.objects.count()
+
         res = PageOfGrants(
             offset=offset,
             limit=limit,
             links={
                 "next": next_
             },
-            total_results=len(grants),
+            total_results=total,
             grants=grants)
         status = 200
     except TypeError:  # TODO: may need different exception

--- a/server/openapi_server/controllers/organization_controller.py
+++ b/server/openapi_server/controllers/organization_controller.py
@@ -112,19 +112,24 @@ def list_organizations(limit=None, offset=None):
     res = None
     status = None
     try:
+        # Get results based on limit and offset.
         db_orgs = DbOrganization.objects.skip(offset).limit(limit)
         orgs = [Organization.from_dict(d.to_dict()) for d in db_orgs]
         next_ = ""
         if len(orgs) == limit:
             next_ = "%s/orgs?limit=%s&offset=%s" % \
                 (Config().server_api_url, limit, offset + limit)
+
+        # Get total results count.
+        total = DbOrganization.objects.count()
+
         res = PageOfOrganizations(
             offset=offset,
             limit=limit,
             links={
                 "next": next_
             },
-            total_results=len(orgs),
+            total_results=total,
             organizations=orgs)
         status = 200
     except TypeError:  # TODO: may need different exception

--- a/server/openapi_server/controllers/organization_controller.py
+++ b/server/openapi_server/controllers/organization_controller.py
@@ -135,3 +135,27 @@ def list_organizations(limit=None, offset=None):
         res = Error("Internal error", status, str(error))
 
     return res, status
+
+
+def delete_all_organizations():
+    """Delete all organizations
+
+    Delete all organizations # noqa: E501
+
+
+    :rtype: object
+    """
+    res = None
+    status = None
+    try:
+        DbOrganization.objects.delete()
+        res = {}
+        status = 200
+    # TODO: find an exception that will raise 400 error
+    # except DoesNotExist:
+    #     status = 400
+    #     res = Error("Bad request", status)
+    except Exception as error:
+        status = 500
+        res = Error("Internal error", status, str(error))
+    return res, status

--- a/server/openapi_server/controllers/person_controller.py
+++ b/server/openapi_server/controllers/person_controller.py
@@ -158,3 +158,26 @@ def list_persons(limit=None, offset=None, filter_=None):
         res = Error("Internal error", status, str(error))
 
     return res, status
+
+
+def delete_all_persons():
+    """Delete all persons
+
+    Delete all persons # noqa: E501
+
+    :rtype: object
+    """
+    res = None
+    status = None
+    try:
+        DbPerson.objects.delete()
+        res = {}
+        status = 200
+    # TODO: find an exception that will raise 400 error
+    # except DoesNotExist:
+    #     status = 400
+    #     res = Error("Bad request", status)
+    except Exception as error:
+        status = 500
+        res = Error("Internal error", status, str(error))
+    return res, status

--- a/server/openapi_server/controllers/person_controller.py
+++ b/server/openapi_server/controllers/person_controller.py
@@ -125,6 +125,7 @@ def list_persons(limit=None, offset=None, filter_=None):
     res = None
     status = None
     try:
+        # Get results based on query, limit and offset.
         first_name_q = Q(firstName__istartswith=filter_['firstName']) \
             if 'firstName' in filter_ else Q()
         last_name_q = Q(lastName__istartswith=filter_['lastName']) \
@@ -141,13 +142,17 @@ def list_persons(limit=None, offset=None, filter_=None):
         if len(persons) == limit:
             next_ = "%s/persons?limit=%s&offset=%s" % \
                 (Config().server_api_url, limit, offset + limit)
+
+        # Get total results count.
+        total = DbPerson.objects.count()
+
         res = PageOfPersons(
             offset=offset,
             limit=limit,
             links={
                 "next": next_
             },
-            total_results=len(persons),
+            total_results=total,
             persons=persons)
         status = 200
     except TypeError:  # TODO: may need different exception

--- a/server/openapi_server/controllers/tag_controller.py
+++ b/server/openapi_server/controllers/tag_controller.py
@@ -111,6 +111,7 @@ def list_tags(limit=None, offset=None, filter_=None):
     res = None
     status = None
     try:
+        # Get results based on query, limit and offset.
         tag_id_q = Q(tagId__istartswith=filter_['tagId']) \
             if 'tagId' in filter_ else Q()
         db_tags = DbTag.objects(tag_id_q).skip(offset).limit(limit)
@@ -119,13 +120,17 @@ def list_tags(limit=None, offset=None, filter_=None):
         if len(tags) == limit:
             next_ = "%s/tags?limit=%s&offset=%s" % \
                 (Config().server_api_url, limit, offset + limit)
+
+        # Get total results count.
+        total = DbTag.objects.count()
+
         res = PageOfTags(
             offset=offset,
             limit=limit,
             links={
                 "next": next_
             },
-            total_results=len(tags),
+            total_results=total,
             tags=tags)
         status = 200
     except TypeError:  # TODO: may need different exception

--- a/server/openapi_server/controllers/tag_controller.py
+++ b/server/openapi_server/controllers/tag_controller.py
@@ -136,3 +136,26 @@ def list_tags(limit=None, offset=None, filter_=None):
         res = Error("Internal error", status, str(error))
 
     return res, status
+
+
+def delete_all_tags():
+    """Delete all tags
+
+    Delete all tags # noqa: E501
+
+    :rtype: object
+    """
+    res = None
+    status = None
+    try:
+        DbTag.objects.delete()
+        res = {}
+        status = 200
+    # TODO: find an exception that will raise 400 error
+    # except DoesNotExist:
+    #     status = 400
+    #     res = Error("Bad request", status)
+    except Exception as error:
+        status = 500
+        res = Error("Internal error", status, str(error))
+    return res, status

--- a/server/openapi_server/controllers/user_controller.py
+++ b/server/openapi_server/controllers/user_controller.py
@@ -129,19 +129,24 @@ def list_users(limit=None, offset=None):
     res = None
     status = None
     try:
+        # Get results based on limit and offset.
         db_users = DbUser.objects.skip(offset).limit(limit)
         users = [User.from_dict(d.to_dict()) for d in db_users]
         next_ = ""
         if len(users) == limit:
             next_ = "%s/orgs?limit=%s&offset=%s" % \
                 (Config().server_api_url, limit, offset + limit)
+
+        # Get total results count.
+        total = DbUser.objects.count()
+
         res = PageOfUsers(
             offset=offset,
             limit=limit,
             links={
                 "next": next_
             },
-            total_results=len(users),
+            total_results=total,
             users=users)
         status = 200
     except TypeError:  # TODO: may need different exception

--- a/server/openapi_server/controllers/user_controller.py
+++ b/server/openapi_server/controllers/user_controller.py
@@ -152,3 +152,26 @@ def list_users(limit=None, offset=None):
         res = Error("Internal error", status, str(error))
 
     return res, status
+
+
+def delete_all_users():
+    """Delete all users
+
+    Delete all users # noqa: E501
+
+    :rtype: object
+    """
+    res = None
+    status = None
+    try:
+        DbUser.objects.delete()
+        res = {}
+        status = 200
+    # TODO: find an exception that will raise 400 error
+    # except DoesNotExist:
+    #     status = 400
+    #     res = Error("Bad request", status)
+    except Exception as error:
+        status = 500
+        res = Error("Internal error", status, str(error))
+    return res, status

--- a/server/openapi_server/openapi/openapi.yaml
+++ b/server/openapi_server/openapi/openapi.yaml
@@ -38,6 +38,33 @@ tags:
   name: User
 paths:
   /challenges:
+    delete:
+      description: Delete all challenges
+      operationId: delete_all_challenges
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyObject'
+          description: Success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      summary: Delete all challenges
+      tags:
+      - Challenge
+      x-openapi-router-controller: openapi_server.controllers.challenge_controller
     get:
       description: Returns all the challenges
       operationId: list_challenges
@@ -208,6 +235,33 @@ paths:
       - Challenge
       x-openapi-router-controller: openapi_server.controllers.challenge_controller
   /grants:
+    delete:
+      description: Delete all grants
+      operationId: delete_all_grants
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyObject'
+          description: Success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      summary: Delete all grants
+      tags:
+      - Grant
+      x-openapi-router-controller: openapi_server.controllers.grant_controller
     get:
       description: Returns the grants
       operationId: list_grants
@@ -369,6 +423,33 @@ paths:
       - Grant
       x-openapi-router-controller: openapi_server.controllers.grant_controller
   /organizations:
+    delete:
+      description: Delete all organizations
+      operationId: delete_all_organizations
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyObject'
+          description: Success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      summary: Delete all organizations
+      tags:
+      - Organization
+      x-openapi-router-controller: openapi_server.controllers.organization_controller
     get:
       description: Returns the organizations
       operationId: list_organizations
@@ -539,6 +620,33 @@ paths:
       - Organization
       x-openapi-router-controller: openapi_server.controllers.organization_controller
   /persons:
+    delete:
+      description: Delete all persons
+      operationId: delete_all_persons
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyObject'
+          description: Success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      summary: Delete all persons
+      tags:
+      - Person
+      x-openapi-router-controller: openapi_server.controllers.person_controller
     get:
       description: Returns the persons
       operationId: list_persons
@@ -708,6 +816,33 @@ paths:
       - Person
       x-openapi-router-controller: openapi_server.controllers.person_controller
   /tags:
+    delete:
+      description: Delete all tags
+      operationId: delete_all_tags
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyObject'
+          description: Success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      summary: Delete all tags
+      tags:
+      - Tag
+      x-openapi-router-controller: openapi_server.controllers.tag_controller
     get:
       description: Returns the tags
       operationId: list_tags
@@ -886,6 +1021,33 @@ paths:
       - Tag
       x-openapi-router-controller: openapi_server.controllers.tag_controller
   /users:
+    delete:
+      description: Delete all users
+      operationId: delete_all_users
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyObject'
+          description: Success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      summary: Delete all users
+      tags:
+      - User
+      x-openapi-router-controller: openapi_server.controllers.user_controller
     get:
       description: Returns the users
       operationId: list_users
@@ -1523,6 +1685,7 @@ components:
           description: Link to the next page of results
           format: uri
           type: string
+      type: object
     PageOfChallenges_allOf:
       properties:
         challenges:
@@ -1530,6 +1693,7 @@ components:
           items:
             $ref: '#/components/schemas/Challenge'
           type: array
+      type: object
     PageOfGrants_allOf:
       properties:
         grants:
@@ -1537,6 +1701,7 @@ components:
           items:
             $ref: '#/components/schemas/Grant'
           type: array
+      type: object
     PageOfOrganizations_allOf:
       properties:
         organizations:
@@ -1544,6 +1709,7 @@ components:
           items:
             $ref: '#/components/schemas/Organization'
           type: array
+      type: object
     PageOfPersons_allOf:
       properties:
         persons:
@@ -1551,6 +1717,7 @@ components:
           items:
             $ref: '#/components/schemas/Person'
           type: array
+      type: object
     PageOfTags_allOf:
       properties:
         tags:
@@ -1558,6 +1725,7 @@ components:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
+      type: object
     PageOfUsers_allOf:
       properties:
         users:
@@ -1565,3 +1733,4 @@ components:
           items:
             $ref: '#/components/schemas/User'
           type: array
+      type: object


### PR DESCRIPTION
With this PR:

* add functionality for deleting all entities of one schema type to controllers (related to this [PR](https://github.com/Sage-Bionetworks/rocc-schemas/pull/69))
* fix `totalResults` bug (#68)