### PR TITLE
Prepare release 0.4.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -108,19 +108,23 @@ Maintainers are required to follow the procedure below when creating a new
 release. Releases are created with the npm package [release-it].
 
 1. [Identify whether the release is a major, minor or patch release.]
-1. Obtain a [personal access token] (release-it only needs "repo" access; no
+2. Bump the project version in the files listed below but not in `package.json`
+   (updated automatically by `release-it`).
+   - `README.md`
+   - `docker-compose.yml`
+3. Obtain a [personal access token] (release-it only needs "repo" access; no
    "admin" or other scopes).
-2. Make sure the token is [available as an environment variable].
-3. Preview the release information using one of the commands listed below. These
+4. Make sure the token is [available as an environment variable].
+5. Preview the release information using one of the commands listed below. These
    commands will not modify any local or remote files.
     - `npm run release -- major --ci --dry-run`
     - `npm run release -- minor --ci --dry-run`
     - `npm run release -- patch --ci --dry-run`
-4. Create the release using one of the commands listed below.
+6. Create the release using one of the commands listed below.
     - `npm run release -- major --ci`
     - `npm run release -- minor --ci`
     - `npm run release -- patch --ci`
-5. Check that the release has been successfully created on GitHub along with any
+7. Check that the release has been successfully created on GitHub along with any
    release artifacts that may have been created (GitHub Pages, Docker image
    pushed to Docker registry, Python package published to PyPi, etc.).
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     labels:
       - docker
       - dependencies
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "docker"
     directory: "/server"
@@ -18,6 +19,7 @@ updates:
     labels:
       - docker
       - dependencies
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,6 +29,7 @@ updates:
     labels:
       - docker
       - gh-actions
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -36,6 +39,7 @@ updates:
     labels:
       - docker
       - npm
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "pip"
     directory: "/server"
@@ -45,3 +49,4 @@ updates:
     labels:
       - docker
       - python
+    open-pull-requests-limit: 0

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Push new version to $GITHUB_ENV
         run: |
           new_version=${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}
-          echo "NEW_VERSION=$(echo $new_version)" >> $GITHUB_ENV
+          echo "new_version=$(echo $new_version)" >> $GITHUB_ENV
 
       - name: Start updating this project
         run: |
@@ -37,8 +37,8 @@ jobs:
       - name: Send pull request to update to new version
         uses: peter-evans/create-pull-request@v3
         with:
-          title: Update to ROCC schemas ${{ env.NEW_VERSION }}
-          commit-message: Update to ROCC schemas ${{ env.NEW_VERSION }}
+          title: Update to ROCC schemas ${{ env.new_version }}
+          commit-message: Update to ROCC schemas ${{ env.new_version }}
           body: |
             A new version of the [ROCC schemas] is available.
 
@@ -51,7 +51,7 @@ jobs:
                specification.
 
                   `npm run generate:server:version --schemas-version=${{
-                  env.NEW_VERSION }}`
+                  env.new_version }}`
 
             3. Review the updates made to this tool in the [ROCC schemas
                CHANGELOG].

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ specification] (schemas).
 
 ## Specification
 
-- ROCC schemas version: 0.2.0
 - ROCC service version: 0.4.0
+- ROCC schemas version: 0.2.0
 - Docker image: [sagebionetworks/rocc-service]
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "version": "0.3.0",
             "devDependencies": {
                 "@openapitools/openapi-generator-cli": "2.3.9",
-                "release-it": "^14.10.1
+                "release-it": "^14.10.1"
             }
         },
         "node_modules/@babel/code-frame": {


### PR DESCRIPTION
> Note: A mistake led to the deletion and re-creation of the branch `0.4.x` used in this PR. If you have an issue that may be related to this, remove your local branch `0.4.x` (old) and fetch/check it out again.

### Changelog

- Bump project version to 0.4.0
- August monthly update (already in the branch `main`)
- #125 
  - #146 
- Disable dependabot dependencies
- #150 