### PR TITLE
Back too camel case for DB model properties

### DIFF
--- a/server/openapi_server/controllers/challenge_controller.py
+++ b/server/openapi_server/controllers/challenge_controller.py
@@ -46,16 +46,16 @@ def create_challenge(account_name):  # noqa: E501
 
             challenge = DbChallenge(
               name=challenge_create_request.name,
-              display_name=challenge_create_request.display_name,
+              displayName=challenge_create_request.display_name,
               description=challenge_create_request.description,
-              website_url=challenge_create_request.website_url,
+              websiteUrl=challenge_create_request.website_url,
               status=challenge_create_request.status,
-              start_date=challenge_create_request.start_date,
-              end_date=challenge_create_request.end_date,
-              platform_id=challenge_create_request.platform_id,
+              startDate=challenge_create_request.start_date,
+              endDate=challenge_create_request.end_date,
+              platformId=challenge_create_request.platform_id,
               doi=challenge_create_request.doi,
-              full_name="%s/%s" % (account_name, challenge_create_request.name),
-              owner_id=account_id
+              fullName="%s/%s" % (account_name, challenge_create_request.name),
+              ownerId=account_id
             ).save()
             challenge_id = challenge.to_dict().get("id")
             res = ChallengeCreateResponse(id=challenge_id)
@@ -136,7 +136,7 @@ def get_challenge(account_name, challenge_name):  # noqa: E501
         account = DbAccount.objects.get(login=account_name)
         account_id = account.to_dict().get("id")
 
-        db_user = DbChallenge.objects.get(owner_id=account_id, name=challenge_name)  # noqa: E501
+        db_user = DbChallenge.objects.get(ownerId=account_id, name=challenge_name)  # noqa: E501
         res = Challenge.from_dict(db_user.to_dict())
         status = 200
     except DoesNotExist:

--- a/server/openapi_server/controllers/challenge_platform_controller.py
+++ b/server/openapi_server/controllers/challenge_platform_controller.py
@@ -22,9 +22,9 @@ def create_challenge_platform():  # noqa: E501
             challenge_platform_create_request = ChallengePlatformCreateRequest.from_dict(connexion.request.get_json())  # noqa: E501
             challenge_platform = DbChallengePlatform(
                 name=challenge_platform_create_request.name,
-                display_name=challenge_platform_create_request.display_name,
-                website_url=challenge_platform_create_request.website_url,
-                avatar_url=challenge_platform_create_request.avatar_url
+                displayName=challenge_platform_create_request.display_name,
+                websiteUrl=challenge_platform_create_request.website_url,
+                avatarUrl=challenge_platform_create_request.avatar_url
             ).save()
             challenge_platform_id = challenge_platform.to_dict().get("id")
             res = ChallengePlatformCreateResponse(id=challenge_platform_id)

--- a/server/openapi_server/controllers/org_membership_controller.py
+++ b/server/openapi_server/controllers/org_membership_controller.py
@@ -27,8 +27,8 @@ def create_org_membership():  # noqa: E501
             org = DbOrgMembership(
                 state=org_membership_request.state,
                 role=org_membership_request.role,
-                organization_id=org_membership_request.organization_id,
-                user_id=org_membership_request.user_id
+                organizationId=org_membership_request.organization_id,
+                userId=org_membership_request.user_id
             ).save()
             org_id = org.to_dict().get("id")
             res = OrgMembershipCreateResponse(id=org_id)
@@ -126,9 +126,9 @@ def list_org_memberships(limit=None, offset=None, org_id=None, user_id=None):  #
     :rtype: PageOfOrgMemberships
     """
     try:
-        org_id_q = Q(organization_id=org_id) \
+        org_id_q = Q(organizationId=org_id) \
             if org_id is not None else Q()
-        user_id_q = Q(user_id=user_id) \
+        user_id_q = Q(userId=user_id) \
             if user_id is not None else Q()
 
         db_org_memberships = DbOrgMembership.objects(

--- a/server/openapi_server/controllers/user_controller.py
+++ b/server/openapi_server/controllers/user_controller.py
@@ -24,7 +24,7 @@ def create_user():  # noqa: E501
                 login=user_create_request.login,
                 email=user_create_request.email,
                 name=user_create_request.name,
-                avatar_url=user_create_request.avatar_url,
+                avatarUrl=user_create_request.avatar_url,
                 type="User"  # TODO: Use enum value
             ).save()
             user_id = user.to_dict().get("id")

--- a/server/openapi_server/dbmodels/challenge.py
+++ b/server/openapi_server/dbmodels/challenge.py
@@ -14,18 +14,18 @@ from openapi_server.dbmodels.challenge_platform import ChallengePlatform
 class Challenge(Document):
     id = ObjectIdField(primary_key=True, default=ObjectId)
     name = StringField(required=True)
-    display_name = StringField(min_length=3, max_length=60)
+    displayName = StringField(min_length=3, max_length=60)
     description = StringField(required=True)
-    full_name = StringField(required=True, unique=True)
-    owner_id = ReferenceField(Account)
-    website_url = URLField()
+    fullName = StringField(required=True, unique=True)
+    ownerId = ReferenceField(Account)
+    websiteUrl = URLField()
     status = StringField(
         required=True,
         choices=["active", "upcoming", "completed"]  # TODO: DRY
     )
-    start_date = DateTimeField()
-    end_date = DateTimeField()
-    platform_id = ReferenceField(ChallengePlatform)
+    startDate = DateTimeField()
+    endDate = DateTimeField()
+    platformId = ReferenceField(ChallengePlatform)
     doi = StringField()
 
     # summary = StringField()

--- a/server/openapi_server/dbmodels/challenge_platform.py
+++ b/server/openapi_server/dbmodels/challenge_platform.py
@@ -6,11 +6,11 @@ from mongoengine import DateTimeField, Document, ObjectIdField, StringField, URL
 class ChallengePlatform(Document):
     id = ObjectIdField(primary_key=True, default=ObjectId)
     name = StringField(required=True, unique=True)
-    display_name = StringField(required=True, unique=True)
-    website_url = URLField(required=True)
-    avatar_url = URLField()
-    created_at = DateTimeField(required=True, default=datetime.datetime.now)
-    updated_at = DateTimeField(required=True, default=datetime.datetime.now)
+    displayName = StringField(required=True, unique=True)
+    websiteUrl = URLField(required=True)
+    avatarUrl = URLField()
+    createdAt = DateTimeField(required=True, default=datetime.datetime.now)
+    updatedAt = DateTimeField(required=True, default=datetime.datetime.now)
 
     def to_dict(self):
         doc = self.to_mongo().to_dict()

--- a/server/openapi_server/dbmodels/org_membership.py
+++ b/server/openapi_server/dbmodels/org_membership.py
@@ -13,8 +13,8 @@ class OrgMembership(Document):
         required=True,
         choices=["admin", "member"]  # TODO: DRY
     )
-    organization_id = ReferenceField(Organization)
-    user_id = ReferenceField(User, unique_with='organization_id')
+    organizationId = ReferenceField(Organization)
+    userId = ReferenceField(User, unique_with='organizationId')
 
     def to_dict(self):
         doc = self.to_mongo().to_dict()

--- a/server/openapi_server/dbmodels/organization.py
+++ b/server/openapi_server/dbmodels/organization.py
@@ -7,10 +7,10 @@ from openapi_server.dbmodels.account import Account
 class Organization(Account):
     email = EmailField()
     name = StringField()
-    avatar_url = URLField()
+    avatarUrl = URLField()
     description = StringField()
-    created_at = DateTimeField(required=True, default=datetime.datetime.now)
-    updated_at = DateTimeField(required=True, default=datetime.datetime.now)
+    createdAt = DateTimeField(required=True, default=datetime.datetime.now)
+    updatedAt = DateTimeField(required=True, default=datetime.datetime.now)
 
     def to_dict(self):
         doc = self.to_mongo().to_dict()

--- a/server/openapi_server/dbmodels/user.py
+++ b/server/openapi_server/dbmodels/user.py
@@ -7,9 +7,9 @@ from openapi_server.dbmodels.account import Account
 class User(Account):
     email = EmailField()
     name = StringField()
-    avatar_url = URLField()
-    created_at = DateTimeField(required=True, default=datetime.datetime.now)
-    updated_at = DateTimeField(required=True, default=datetime.datetime.now)
+    avatarUrl = URLField()
+    createdAt = DateTimeField(required=True, default=datetime.datetime.now)
+    updatedAt = DateTimeField(required=True, default=datetime.datetime.now)
 
     def to_dict(self):
         doc = self.to_mongo().to_dict()


### PR DESCRIPTION
Undo #163 because the method `from_dict` generated by openapi-generator expects camel case properties. An alternative would be to use snake case in the OpenAPI document, but then we need to update the clients (client library and web client).