### PR TITLE
Protect all endpoints

### DIFF
--- a/server/openapi_server/__main__.py
+++ b/server/openapi_server/__main__.py
@@ -22,7 +22,7 @@ connect(
 
 
 def main():
-    app.run(port=8080, debug=False)
+    app.run(port=8080, debug=True)
 
 
 if __name__ == '__main__':

--- a/server/openapi_server/__main__.py
+++ b/server/openapi_server/__main__.py
@@ -22,7 +22,7 @@ connect(
 
 
 def main():
-    app.run(port=8080, debug=True)
+    app.run(port=8080, debug=False)
 
 
 if __name__ == '__main__':

--- a/server/openapi_server/__main__.py
+++ b/server/openapi_server/__main__.py
@@ -13,6 +13,8 @@ app.add_api('openapi.yaml', pythonic_params=True)
 
 app.add_url_rule('/ui', 'ui', lambda: flask.redirect('/api/v1/ui'))
 
+print(f'Server secret key: {config.secret_key}')
+
 connect(
     db=config.db_database,
     username=config.db_username,

--- a/server/openapi_server/config.py
+++ b/server/openapi_server/config.py
@@ -1,10 +1,13 @@
 import os
+import string
+import random
+
 
 defaultValues = {
     "SERVER_PROTOCOL": "http://",
     "SERVER_DOMAIN": "localhost",
     "SERVER_PORT": "8080",
-    "SERVER_SECRET_KEY": "roccsecretkey",
+    "SERVER_SECRET_KEY": ''.join(random.sample(string.ascii_letters + string.digits, 32)),  # noqa: E501
     "DB_PROTOCOL": "mongodb://",
     "DB_DOMAIN": "localhost",
     "DB_PORT": "27017",

--- a/server/openapi_server/controllers/security_controller_.py
+++ b/server/openapi_server/controllers/security_controller_.py
@@ -20,8 +20,9 @@ def info_from_ApiKeyAuth(api_key, required_scopes):
         if api_key == config.secret_key:
             return {'uid': 'user_id'}
     except Exception as error:
-        print("Invalid API key.", error)
-        return None
+        print("Invalid API key", error)
+
+    return None
 
 
 def info_from_BearerAuth(token):
@@ -40,7 +41,7 @@ def info_from_BearerAuth(token):
         return {"sub": payload["sub"]}
     except jwt.ExpiredSignatureError as error:
         print("Signature expired. Please log in again.", error)
-        return None
     except jwt.InvalidTokenError as error:
         print("Invalid token. Please log in again.", error)
-        return None
+
+    return None

--- a/server/openapi_server/controllers/security_controller_.py
+++ b/server/openapi_server/controllers/security_controller_.py
@@ -16,9 +16,12 @@ def info_from_ApiKeyAuth(api_key, required_scopes):
     api_key or None if api_key is invalid or does not allow access to called API
     :rtype: dict | None
     """
-    print("API key", api_key)
-    return {'uid': 'user_id'}
-    # return None
+    try:
+        if api_key == config.secret_key:
+            return {'uid': 'user_id'}
+    except Exception as error:
+        print("Invalid API key.", error)
+        return None
 
 
 def info_from_BearerAuth(token):

--- a/server/openapi_server/openapi/openapi.yaml
+++ b/server/openapi_server/openapi/openapi.yaml
@@ -38,8 +38,6 @@ tags:
   name: Organization
 - description: Operations about org memberships
   name: OrgMembership
-- description: Operations about tags
-  name: Tag
 - description: Operations about users
   name: User
 - description: Operations about health checks
@@ -140,6 +138,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete all challenge platforms
       tags:
       - ChallengePlatform
@@ -228,6 +228,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - BearerAuth: []
       summary: Create a challenge platform
       tags:
       - ChallengePlatform
@@ -265,6 +267,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete a challenge platform
       tags:
       - ChallengePlatform
@@ -323,6 +327,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete all challenges
       tags:
       - Challenge
@@ -559,6 +565,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - BearerAuth: []
       summary: Add a challenge
       tags:
       - Challenge
@@ -604,6 +612,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete a challenge
       tags:
       - Challenge
@@ -749,6 +759,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - BearerAuth: []
       summary: Create a challenge organizer
       tags:
       - Challenge
@@ -802,6 +814,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete a challenge organizer
       tags:
       - Challenge
@@ -903,6 +917,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - BearerAuth: []
       summary: Update a challenge README
       tags:
       - Challenge
@@ -1004,6 +1020,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - BearerAuth: []
       summary: Create a challenge sponsor
       tags:
       - Challenge
@@ -1057,6 +1075,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete a challenge sponsor
       tags:
       - Challenge
@@ -1190,6 +1210,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete all grants
       tags:
       - Grant
@@ -1283,6 +1305,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - BearerAuth: []
       summary: Create a grant
       tags:
       - Grant
@@ -1320,6 +1344,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete a grant
       tags:
       - Grant
@@ -1400,6 +1426,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete all org memberships
       tags:
       - OrgMembership
@@ -1541,6 +1569,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete an org membership
       tags:
       - OrgMembership
@@ -1599,6 +1629,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete all organizations
       tags:
       - Organization
@@ -1692,6 +1724,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - BearerAuth: []
       summary: Create an organization
       tags:
       - Organization
@@ -1730,6 +1764,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete an organization
       tags:
       - Organization
@@ -2110,6 +2146,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete all users
       tags:
       - User
@@ -2241,6 +2279,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The request cannot be fulfilled due to an unexpected server
             error
+      security:
+      - ApiKeyAuth: []
       summary: Delete a user
       tags:
       - User


### PR DESCRIPTION
Implements https://github.com/Sage-Bionetworks/rocc-schemas/pull/198

## TODO

- [x] Enable service user to set API key
- [x] Automatically generate an API key if the user does not provide one
- [x] Check value of the API key when calling endpoint protected by it 

## Preview

The server secret key used as an API key can now be set in `.env`:

```bash
SERVER_SECRET_KEY=roccsecretkey
```

If no secret key is set, the server generates one automatically. When the server starts, the API key is displayed.

Now most write endpoints are protected either by the API key or Bearer token. In the future, the API key may be removed and replaced by Bearer token + roles.

![image](https://user-images.githubusercontent.com/3056480/139752176-720002df-40f4-4ce6-986a-981ebb6de5d0.png)
